### PR TITLE
API Service - optional Configuration to every request

### DIFF
--- a/Sources/APILayer/Service/ApiService.swift
+++ b/Sources/APILayer/Service/ApiService.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-final public class ApiService {
+public final class ApiService {
 
     /// Service managing requests
     let requestService: RequestService
@@ -184,8 +184,8 @@ public extension ApiService {
 
      - Returns: ApiRequest object which allows to follow progress and manage request.
      */
-    func postFile(from localFileUrl: URL, to destinationUrl: URL, with aditionalHeaders: [ApiHeader]? = nil, inBackground: Bool = true, useProgress: Bool = true, configuration: ApiService.Configuration = ApiService.Configuration.foreground, completion: ApiResponseCompletionHandler? = nil) -> ApiRequest {
-        let configuration: Configuration = inBackground ? .background : .foreground
+    func postFile(from localFileUrl: URL, to destinationUrl: URL, with aditionalHeaders: [ApiHeader]? = nil, inBackground: Bool? = nil, useProgress: Bool = true, configuration: ApiService.Configuration? = nil, completion: ApiResponseCompletionHandler? = nil) -> ApiRequest {
+        let configuration: Configuration = configurationSetting(when: inBackground, configuration: configuration)
         return uploadFile(at: localFileUrl, to: destinationUrl, method: .post, apiHeaders: aditionalHeaders, configuration: configuration, useProgress: useProgress, completion: completion)
     }
 
@@ -203,8 +203,8 @@ public extension ApiService {
 
      - Returns: ApiRequest object which allows to follow progress and manage request.
      */
-    func putFile(from localFileUrl: URL, to destinationUrl: URL, with aditionalHeaders: [ApiHeader]? = nil, inBackground: Bool = true, useProgress: Bool = true, configuration: ApiService.Configuration = ApiService.Configuration.foreground, completion: ApiResponseCompletionHandler? = nil) -> ApiRequest {
-        let configuration: Configuration = inBackground ? .background : .foreground
+    func putFile(from localFileUrl: URL, to destinationUrl: URL, with aditionalHeaders: [ApiHeader]? = nil, inBackground: Bool? = nil, useProgress: Bool = true, configuration: ApiService.Configuration? = nil, completion: ApiResponseCompletionHandler? = nil) -> ApiRequest {
+        let configuration: Configuration = configurationSetting(when: inBackground, configuration: configuration)
         return uploadFile(at: localFileUrl, to: destinationUrl, method: .put, apiHeaders: aditionalHeaders, configuration: configuration, useProgress: useProgress, completion: completion)
     }
 
@@ -222,8 +222,8 @@ public extension ApiService {
 
      - Returns: ApiRequest object which allows to follow progress and manage request.
      */
-    func patchFile(from localFileUrl: URL, to destinationUrl: URL, with aditionalHeaders: [ApiHeader]? = nil, inBackground: Bool = true, useProgress: Bool = true, configuration: ApiService.Configuration = ApiService.Configuration.foreground, completion: ApiResponseCompletionHandler? = nil) -> ApiRequest {
-        let configuration: Configuration = inBackground ? .background : .foreground
+    func patchFile(from localFileUrl: URL, to destinationUrl: URL, with aditionalHeaders: [ApiHeader]? = nil, inBackground: Bool? = nil, useProgress: Bool = true, configuration: ApiService.Configuration? = nil, completion: ApiResponseCompletionHandler? = nil) -> ApiRequest {
+        let configuration: Configuration = configurationSetting(when: inBackground, configuration: configuration)
         return uploadFile(at: localFileUrl, to: destinationUrl, method: .patch, apiHeaders: aditionalHeaders, configuration: configuration, useProgress: useProgress, completion: completion)
     }
 }
@@ -295,5 +295,16 @@ public extension ApiService {
      */
     func downloadFile(from remoteFileUrl: URL, to localUrl: URL, with aditionalHeaders: [ApiHeader]? = nil, configuration: Configuration = .background, progress: Bool = true, completion: ApiResponseCompletionHandler? = nil) -> ApiRequest {
         return downloadFile(from: remoteFileUrl, to: localUrl, apiHeaders: aditionalHeaders, configuration: configuration, useProgress: progress, completion: completion)
+    }
+}
+
+public extension ApiService {
+    /// Helper method to determine which parameter precedes
+    func configurationSetting(when inBackground: Bool? = nil, configuration: Configuration? = nil) -> Configuration {
+        guard configuration == nil else { return configuration! }
+        guard inBackground == nil else {
+            return inBackground! ? .background : .foreground
+        }
+        return .foreground
     }
 }

--- a/Sources/APILayer/Service/ApiService.swift
+++ b/Sources/APILayer/Service/ApiService.swift
@@ -10,7 +10,7 @@ import Foundation
 
 final public class ApiService {
 
-    ///Service managing requests
+    /// Service managing requests
     let requestService: RequestService
 
     /**
@@ -20,7 +20,7 @@ final public class ApiService {
         self.requestService = RequestService(fileManager: fileManager)
     }
 
-    ///Cancels all currently running requests.
+    /// Cancels all currently running requests.
     public func cancelAllRequests() {
         requestService.cancelAllRequests()
     }
@@ -28,7 +28,7 @@ final public class ApiService {
 
 private extension ApiService {
 
-    ///Converts array of *ApiHeader* to array of *HttpHeader*
+    /// Converts array of *ApiHeader* to array of *HttpHeader*
     func httpHeaders(for apiHeaders: [ApiHeader]?) -> [HttpHeader]? {
         guard let apiHeaders = apiHeaders else {
             return nil
@@ -40,7 +40,7 @@ private extension ApiService {
         return headers
     }
 
-    ///Sends data request with given parameters
+    /// Sends data request with given parameters
     func sendRequest(url: URL, method: ApiMethod, body: Data?, apiHeaders: [ApiHeader]?, configuration: Configuration, useProgress: Bool, completion: ApiResponseCompletionHandler?) -> ApiRequest {
         let headers = httpHeaders(for: apiHeaders)
         let action = ResponseAction.completionActions(for: completion)
@@ -51,8 +51,8 @@ private extension ApiService {
         return ApiRequest(httpRequest: httpRequest, httpRequestService: requestService)
     }
 
-    ///Uploads file with given parameters
-    func uploadFile(at localFileUrl: URL, to destinationUrl: URL, method: ApiMethod, apiHeaders: [ApiHeader]?, configuration: Configuration, useProgress: Bool, completion: ApiResponseCompletionHandler?) -> ApiRequest  {
+    /// Uploads file with given parameters
+    func uploadFile(at localFileUrl: URL, to destinationUrl: URL, method: ApiMethod, apiHeaders: [ApiHeader]?, configuration: Configuration, useProgress: Bool, completion: ApiResponseCompletionHandler?) -> ApiRequest {
         let headers = httpHeaders(for: apiHeaders)
         let action = ResponseAction.completionActions(for: completion)
         let uploadRequest = HttpUploadRequest(url: destinationUrl, method: method.httpMethod, resourceUrl: localFileUrl, headers: headers, onSuccess: action.success, onFailure: action.failure, useProgress: useProgress)
@@ -62,8 +62,8 @@ private extension ApiService {
         return ApiRequest(httpRequest: uploadRequest, httpRequestService: requestService)
     }
 
-    ///Downloads file with given parameters
-    func downloadFile(from remoteFileUrl: URL, to localUrl: URL, apiHeaders: [ApiHeader]?, configuration: Configuration, useProgress: Bool, completion: ApiResponseCompletionHandler?) -> ApiRequest  {
+    /// Downloads file with given parameters
+    func downloadFile(from remoteFileUrl: URL, to localUrl: URL, apiHeaders: [ApiHeader]?, configuration: Configuration, useProgress: Bool, completion: ApiResponseCompletionHandler?) -> ApiRequest {
         let headers = httpHeaders(for: apiHeaders)
         let action = ResponseAction.completionActions(for: completion)
         let downloadRequest = HttpDownloadRequest(url: remoteFileUrl, destinationUrl: localUrl, headers: headers, onSuccess: action.success, onFailure: action.failure, useProgress: useProgress)
@@ -74,18 +74,18 @@ private extension ApiService {
     }
 }
 
-///Manage simple HTTP requests
+/// Manage simple HTTP requests
 public extension ApiService {
 
     /**
      Sends HTTP GET request with given parameters.
 
      - Parameters:
-     - url: URL of the receiver.
-     - aditionalHeaders: Array of all aditional HTTP header fields.
-     - configuration: One of predefined *ApiService.Configuration* object containing request configuration.
-     - useProgress: Flag indicates if Progress object should be created.
-     - completion: Closure called when request is finished.
+         - url: URL of the receiver.
+         - aditionalHeaders: Array of all aditional HTTP header fields.
+         - configuration: One of predefined *ApiService.Configuration* object containing request configuration.
+         - useProgress: Flag indicates if Progress object should be created.
+         - completion: Closure called when request is finished.
 
      - Returns: ApiRequest object which allows to follow progress and manage request.
      */
@@ -98,12 +98,12 @@ public extension ApiService {
      Sends HTTP POST request with given parameters.
 
      - Parameters:
-     - data: Data object which supposed to be send.
-     - url: URL of the receiver.
-     - aditionalHeaders: Array of all aditional HTTP header fields.
-     - configuration: One of predefined *ApiService.Configuration* object containing request configuration.
-     - useProgress: Flag indicates if Progress object should be created.
-     - completion: Closure called when request is finished.
+         - data: Data object which supposed to be send.
+         - url: URL of the receiver.
+         - aditionalHeaders: Array of all aditional HTTP header fields.
+         - configuration: One of predefined *ApiService.Configuration* object containing request configuration.
+         - useProgress: Flag indicates if Progress object should be created.
+         - completion: Closure called when request is finished.
 
      - Returns: ApiRequest object which allows to follow progress and manage request.
      */
@@ -116,12 +116,12 @@ public extension ApiService {
      Sends HTTP PUT request with given parameters.
 
      - Parameters:
-     - data: Data object which supposed to be send.
-     - url: URL of the receiver.
-     - aditionalHeaders: Array of all aditional HTTP header fields.
-     - configuration: One of predefined *ApiService.Configuration* object containing request configuration.
-     - useProgress: Flag indicates if Progress object should be created.
-     - completion: Closure called when request is finished.
+         - data: Data object which supposed to be send.
+         - url: URL of the receiver.
+         - aditionalHeaders: Array of all aditional HTTP header fields.
+         - configuration: One of predefined *ApiService.Configuration* object containing request configuration.
+         - useProgress: Flag indicates if Progress object should be created.
+         - completion: Closure called when request is finished.
 
      - Returns: ApiRequest object which allows to follow progress and manage request.
      */
@@ -134,12 +134,12 @@ public extension ApiService {
      Sends HTTP PATCH request with given parameters.
 
      - Parameters:
-     - data: Data object which supposed to be send.
-     - url: URL of the receiver.
-     - aditionalHeaders: Array of all aditional HTTP header fields.
-     - configuration: One of predefined *ApiService.Configuration* object containing request configuration.
-     - useProgress: Flag indicates if Progress object should be created.
-     - completion: Closure called when request is finished.
+         - data: Data object which supposed to be send.
+         - url: URL of the receiver.
+         - aditionalHeaders: Array of all aditional HTTP header fields.
+         - configuration: One of predefined *ApiService.Configuration* object containing request configuration.
+         - useProgress: Flag indicates if Progress object should be created.
+         - completion: Closure called when request is finished.
 
      - Returns: ApiRequest object which allows to follow progress and manage request.
      */
@@ -152,12 +152,12 @@ public extension ApiService {
      Sends HTTP DELETE request with given parameters.
 
      - Parameters:
-     - data: Data object which supposed to be send.
-     - url: URL of the receiver.
-     - aditionalHeaders: Array of all aditional HTTP header fields.
-     - configuration: One of predefined *ApiService.Configuration* object containing request configuration.
-     - useProgress: Flag indicates if Progress object should be created.
-     - completion: Closure called when request is finished.
+         - data: Data object which supposed to be send.
+         - url: URL of the receiver.
+         - aditionalHeaders: Array of all aditional HTTP header fields.
+         - configuration: One of predefined *ApiService.Configuration* object containing request configuration.
+         - useProgress: Flag indicates if Progress object should be created.
+         - completion: Closure called when request is finished.
 
      - Returns: ApiRequest object which allows to follow progress and manage request.
      */
@@ -167,19 +167,20 @@ public extension ApiService {
     }
 }
 
-///Manage uploading files
+/// Manage uploading files
 public extension ApiService {
 
     /**
      Uploads file using HTTP POST request.
 
      - Parameters:
-     - localFileUrl: URL on disc of the resource to upload.
-     - destinationUrl: URL of the receiver.
-     - aditionalHeaders: Array of all aditional HTTP header fields.
-     - inBackground: Flag indicates if uploading should be performed in background or foreground.
-     - useProgress: Flag indicates if Progress object should be created.
-     - completion: Closure called when request is finished.
+         - localFileUrl: URL on disc of the resource to upload.
+         - destinationUrl: URL of the receiver.
+         - aditionalHeaders: Array of all aditional HTTP header fields.
+         - inBackground: Flag indicates if uploading should be performed in background or foreground.
+         - useProgress: Flag indicates if Progress object should be created.
+         - configuration: One of predefined *ApiService.Configuration* object containing request configuration.
+         - completion: Closure called when request is finished.
 
      - Returns: ApiRequest object which allows to follow progress and manage request.
      */
@@ -192,12 +193,13 @@ public extension ApiService {
      Uploads file using HTTP PUT request.
 
      - Parameters:
-     - localFileUrl: URL on disc of the resource to upload.
-     - destinationUrl: URL of the receiver.
-     - aditionalHeaders: Array of all aditional HTTP header fields.
-     - inBackground: Flag indicates if uploading should be performed in background or foreground.
-     - useProgress: Flag indicates if Progress object should be created.
-     - completion: Closure called when request is finished.
+         - localFileUrl: URL on disc of the resource to upload.
+         - destinationUrl: URL of the receiver.
+         - aditionalHeaders: Array of all aditional HTTP header fields.
+         - inBackground: Flag indicates if uploading should be performed in background or foreground.
+         - useProgress: Flag indicates if Progress object should be created.
+         - configuration: One of predefined *ApiService.Configuration* object containing request configuration.
+         - completion: Closure called when request is finished.
 
      - Returns: ApiRequest object which allows to follow progress and manage request.
      */
@@ -210,12 +212,13 @@ public extension ApiService {
      Uploads file using HTTP PATCH request.
 
      - Parameters:
-     - localFileUrl: URL on disc of the resource to upload.
-     - destinationUrl: URL of the receiver.
-     - aditionalHeaders: Array of all aditional HTTP header fields.
-     - inBackground: Flag indicates if uploading should be performed in background or foreground.
-     - useProgress: Flag indicates if Progress object should be created.
-     - completion: Closure called when request is finished.
+         - localFileUrl: URL on disc of the resource to upload.
+         - destinationUrl: URL of the receiver.
+         - aditionalHeaders: Array of all aditional HTTP header fields.
+         - inBackground: Flag indicates if uploading should be performed in background or foreground.
+         - useProgress: Flag indicates if Progress object should be created.
+         - configuration: One of predefined *ApiService.Configuration* object containing request configuration.
+         - completion: Closure called when request is finished.
 
      - Returns: ApiRequest object which allows to follow progress and manage request.
      */
@@ -225,19 +228,20 @@ public extension ApiService {
     }
 }
 
-///Manage downloading files
+/// Manage downloading files
 public extension ApiService {
 
     /**
      Downloads file using HTTP GET request.
 
      - Parameters:
-     - remoteFileUrl: URL of remote file to download.
-     - localUrl: URL on disc indicates where file should be saved.
-     - aditionalHeaders: Array of all aditional HTTP header fields.
-     - inBackground: Flag indicates if downloading should be performed in background or foreground.
-     - useProgress: Flag indicates if Progress object should be created.
-     - completion: Closure called when request is finished.
+         - remoteFileUrl: URL of remote file to download.
+         - localUrl: URL on disc indicates where file should be saved.
+         - aditionalHeaders: Array of all aditional HTTP header fields.
+         - inBackground: Flag indicates if downloading should be performed in background or foreground.
+         - useProgress: Flag indicates if Progress object should be created.
+         - configuration: One of predefined *ApiService.Configuration* object containing request configuration.
+         - completion: Closure called when request is finished.
 
      - Returns: ApiRequest object which allows to follow progress and manage request.
 
@@ -248,20 +252,21 @@ public extension ApiService {
     }
 }
 
-///Methods allowing extend service capabilities
+/// Methods allowing extend service capabilities
 public extension ApiService {
 
     /**
      Uploads file using HTTP request.
 
      - Parameters:
-     - localFileUrl: URL on disc of the resource to upload.
-     - destinationUrl: URL of the receiver.
-     - method: HTTP method which should be used.
-     - aditionalHeaders: Array of all aditional HTTP header fields.
-     - configuration: Custom or one of predefined *ApiService.Configuration* object.
-     - progress: Flag indicates if Progress object should be created.
-     - completion: Closure called when request is finished.
+         - localFileUrl: URL on disc of the resource to upload.
+         - destinationUrl: URL of the receiver.
+         - method: HTTP method which should be used.
+         - aditionalHeaders: Array of all aditional HTTP header fields.
+         - configuration: Custom or one of predefined *ApiService.Configuration* object.
+         - progress: Flag indicates if Progress object should be created.
+         - configuration: One of predefined *ApiService.Configuration* object containing request configuration.
+         - completion: Closure called when request is finished.
 
      - Returns: ApiRequest object which allows to follow progress and manage request.
 
@@ -275,12 +280,12 @@ public extension ApiService {
      Downloads file using HTTP GET request.
 
      - Parameters:
-     - remoteFileUrl: URL of remote file to download.
-     - localUrl: URL on disc indicates where file should be saved.
-     - aditionalHeaders: Array of all aditional HTTP header fields.
-     - configuration: Custom or one of predefined *ApiService.Configuration* object.
-     - progress: Flag indicates if Progress object should be created.
-     - completion: Closure called when request is finished.
+         - remoteFileUrl: URL of remote file to download.
+         - localUrl: URL on disc indicates where file should be saved.
+         - aditionalHeaders: Array of all aditional HTTP header fields.
+         - configuration: Custom or one of predefined *ApiService.Configuration* object.
+         - progress: Flag indicates if Progress object should be created.
+         - completion: Closure called when request is finished.
 
      - Returns: ApiRequest object which allows to follow progress and manage request.
 

--- a/Sources/APILayer/Service/ApiService.swift
+++ b/Sources/APILayer/Service/ApiService.swift
@@ -244,7 +244,6 @@ public extension ApiService {
      - Important: While using default file manager, if any file exists at *localUrl* it will be overridden by downloaded file.
      */
     func downloadFile(from remoteFileUrl: URL, to localUrl: URL, with aditionalHeaders: [ApiHeader]? = nil, inBackground: Bool = true, useProgress: Bool = true, configuration: ApiService.Configuration = ApiService.Configuration.background, completion: ApiResponseCompletionHandler? = nil) -> ApiRequest {
-        //        let configuration: Configuration = inBackground ? .background : .foreground
         return downloadFile(from: remoteFileUrl, to: localUrl, apiHeaders: aditionalHeaders, configuration: configuration, useProgress: useProgress, completion: completion)
     }
 }

--- a/Sources/APILayer/Service/ApiService.swift
+++ b/Sources/APILayer/Service/ApiService.swift
@@ -247,7 +247,8 @@ public extension ApiService {
 
      - Important: While using default file manager, if any file exists at *localUrl* it will be overridden by downloaded file.
      */
-    func downloadFile(from remoteFileUrl: URL, to localUrl: URL, with aditionalHeaders: [ApiHeader]? = nil, inBackground: Bool = true, useProgress: Bool = true, configuration: ApiService.Configuration = ApiService.Configuration.background, completion: ApiResponseCompletionHandler? = nil) -> ApiRequest {
+    func downloadFile(from remoteFileUrl: URL, to localUrl: URL, with aditionalHeaders: [ApiHeader]? = nil, inBackground: Bool? = nil, useProgress: Bool = true, configuration: ApiService.Configuration? = nil, completion: ApiResponseCompletionHandler? = nil) -> ApiRequest {
+        let configuration: Configuration = configurationSetting(when: inBackground, configuration: configuration)
         return downloadFile(from: remoteFileUrl, to: localUrl, apiHeaders: aditionalHeaders, configuration: configuration, useProgress: useProgress, completion: completion)
     }
 }

--- a/Sources/APILayer/Service/ApiService.swift
+++ b/Sources/APILayer/Service/ApiService.swift
@@ -81,11 +81,11 @@ public extension ApiService {
      Sends HTTP GET request with given parameters.
 
      - Parameters:
-       - url: URL of the receiver.
-       - aditionalHeaders: Array of all aditional HTTP header fields.
-       - configuration: One of predefined *ApiService.Configuration* object containing request configuration.
-       - useProgress: Flag indicates if Progress object should be created.
-       - completion: Closure called when request is finished.
+     - url: URL of the receiver.
+     - aditionalHeaders: Array of all aditional HTTP header fields.
+     - configuration: One of predefined *ApiService.Configuration* object containing request configuration.
+     - useProgress: Flag indicates if Progress object should be created.
+     - completion: Closure called when request is finished.
 
      - Returns: ApiRequest object which allows to follow progress and manage request.
      */
@@ -98,12 +98,12 @@ public extension ApiService {
      Sends HTTP POST request with given parameters.
 
      - Parameters:
-       - data: Data object which supposed to be send.
-       - url: URL of the receiver.
-       - aditionalHeaders: Array of all aditional HTTP header fields.
-       - configuration: One of predefined *ApiService.Configuration* object containing request configuration.
-       - useProgress: Flag indicates if Progress object should be created.
-       - completion: Closure called when request is finished.
+     - data: Data object which supposed to be send.
+     - url: URL of the receiver.
+     - aditionalHeaders: Array of all aditional HTTP header fields.
+     - configuration: One of predefined *ApiService.Configuration* object containing request configuration.
+     - useProgress: Flag indicates if Progress object should be created.
+     - completion: Closure called when request is finished.
 
      - Returns: ApiRequest object which allows to follow progress and manage request.
      */
@@ -116,12 +116,12 @@ public extension ApiService {
      Sends HTTP PUT request with given parameters.
 
      - Parameters:
-       - data: Data object which supposed to be send.
-       - url: URL of the receiver.
-       - aditionalHeaders: Array of all aditional HTTP header fields.
-       - configuration: One of predefined *ApiService.Configuration* object containing request configuration.
-       - useProgress: Flag indicates if Progress object should be created.
-       - completion: Closure called when request is finished.
+     - data: Data object which supposed to be send.
+     - url: URL of the receiver.
+     - aditionalHeaders: Array of all aditional HTTP header fields.
+     - configuration: One of predefined *ApiService.Configuration* object containing request configuration.
+     - useProgress: Flag indicates if Progress object should be created.
+     - completion: Closure called when request is finished.
 
      - Returns: ApiRequest object which allows to follow progress and manage request.
      */
@@ -134,12 +134,12 @@ public extension ApiService {
      Sends HTTP PATCH request with given parameters.
 
      - Parameters:
-       - data: Data object which supposed to be send.
-       - url: URL of the receiver.
-       - aditionalHeaders: Array of all aditional HTTP header fields.
-       - configuration: One of predefined *ApiService.Configuration* object containing request configuration.
-       - useProgress: Flag indicates if Progress object should be created.
-       - completion: Closure called when request is finished.
+     - data: Data object which supposed to be send.
+     - url: URL of the receiver.
+     - aditionalHeaders: Array of all aditional HTTP header fields.
+     - configuration: One of predefined *ApiService.Configuration* object containing request configuration.
+     - useProgress: Flag indicates if Progress object should be created.
+     - completion: Closure called when request is finished.
 
      - Returns: ApiRequest object which allows to follow progress and manage request.
      */
@@ -152,12 +152,12 @@ public extension ApiService {
      Sends HTTP DELETE request with given parameters.
 
      - Parameters:
-       - data: Data object which supposed to be send.
-       - url: URL of the receiver.
-       - aditionalHeaders: Array of all aditional HTTP header fields.
-       - configuration: One of predefined *ApiService.Configuration* object containing request configuration.
-       - useProgress: Flag indicates if Progress object should be created.
-       - completion: Closure called when request is finished.
+     - data: Data object which supposed to be send.
+     - url: URL of the receiver.
+     - aditionalHeaders: Array of all aditional HTTP header fields.
+     - configuration: One of predefined *ApiService.Configuration* object containing request configuration.
+     - useProgress: Flag indicates if Progress object should be created.
+     - completion: Closure called when request is finished.
 
      - Returns: ApiRequest object which allows to follow progress and manage request.
      */
@@ -174,16 +174,16 @@ public extension ApiService {
      Uploads file using HTTP POST request.
 
      - Parameters:
-       - localFileUrl: URL on disc of the resource to upload.
-       - destinationUrl: URL of the receiver.
-       - aditionalHeaders: Array of all aditional HTTP header fields.
-       - inBackground: Flag indicates if uploading should be performed in background or foreground.
-       - useProgress: Flag indicates if Progress object should be created.
-       - completion: Closure called when request is finished.
+     - localFileUrl: URL on disc of the resource to upload.
+     - destinationUrl: URL of the receiver.
+     - aditionalHeaders: Array of all aditional HTTP header fields.
+     - inBackground: Flag indicates if uploading should be performed in background or foreground.
+     - useProgress: Flag indicates if Progress object should be created.
+     - completion: Closure called when request is finished.
 
      - Returns: ApiRequest object which allows to follow progress and manage request.
      */
-    func postFile(from localFileUrl: URL, to destinationUrl: URL, with aditionalHeaders: [ApiHeader]? = nil, inBackground: Bool = true, useProgress: Bool = true, completion: ApiResponseCompletionHandler? = nil) -> ApiRequest {
+    func postFile(from localFileUrl: URL, to destinationUrl: URL, with aditionalHeaders: [ApiHeader]? = nil, inBackground: Bool = true, useProgress: Bool = true, configuration: ApiService.Configuration = ApiService.Configuration.foreground, completion: ApiResponseCompletionHandler? = nil) -> ApiRequest {
         let configuration: Configuration = inBackground ? .background : .foreground
         return uploadFile(at: localFileUrl, to: destinationUrl, method: .post, apiHeaders: aditionalHeaders, configuration: configuration, useProgress: useProgress, completion: completion)
     }
@@ -192,16 +192,16 @@ public extension ApiService {
      Uploads file using HTTP PUT request.
 
      - Parameters:
-       - localFileUrl: URL on disc of the resource to upload.
-       - destinationUrl: URL of the receiver.
-       - aditionalHeaders: Array of all aditional HTTP header fields.
-       - inBackground: Flag indicates if uploading should be performed in background or foreground.
-       - useProgress: Flag indicates if Progress object should be created.
-       - completion: Closure called when request is finished.
+     - localFileUrl: URL on disc of the resource to upload.
+     - destinationUrl: URL of the receiver.
+     - aditionalHeaders: Array of all aditional HTTP header fields.
+     - inBackground: Flag indicates if uploading should be performed in background or foreground.
+     - useProgress: Flag indicates if Progress object should be created.
+     - completion: Closure called when request is finished.
 
      - Returns: ApiRequest object which allows to follow progress and manage request.
      */
-    func putFile(from localFileUrl: URL, to destinationUrl: URL, with aditionalHeaders: [ApiHeader]? = nil, inBackground: Bool = true, useProgress: Bool = true, completion: ApiResponseCompletionHandler? = nil) -> ApiRequest {
+    func putFile(from localFileUrl: URL, to destinationUrl: URL, with aditionalHeaders: [ApiHeader]? = nil, inBackground: Bool = true, useProgress: Bool = true, configuration: ApiService.Configuration = ApiService.Configuration.foreground, completion: ApiResponseCompletionHandler? = nil) -> ApiRequest {
         let configuration: Configuration = inBackground ? .background : .foreground
         return uploadFile(at: localFileUrl, to: destinationUrl, method: .put, apiHeaders: aditionalHeaders, configuration: configuration, useProgress: useProgress, completion: completion)
     }
@@ -210,16 +210,16 @@ public extension ApiService {
      Uploads file using HTTP PATCH request.
 
      - Parameters:
-       - localFileUrl: URL on disc of the resource to upload.
-       - destinationUrl: URL of the receiver.
-       - aditionalHeaders: Array of all aditional HTTP header fields.
-       - inBackground: Flag indicates if uploading should be performed in background or foreground.
-       - useProgress: Flag indicates if Progress object should be created.
-       - completion: Closure called when request is finished.
+     - localFileUrl: URL on disc of the resource to upload.
+     - destinationUrl: URL of the receiver.
+     - aditionalHeaders: Array of all aditional HTTP header fields.
+     - inBackground: Flag indicates if uploading should be performed in background or foreground.
+     - useProgress: Flag indicates if Progress object should be created.
+     - completion: Closure called when request is finished.
 
      - Returns: ApiRequest object which allows to follow progress and manage request.
      */
-    func patchFile(from localFileUrl: URL, to destinationUrl: URL, with aditionalHeaders: [ApiHeader]? = nil, inBackground: Bool = true, useProgress: Bool = true, completion: ApiResponseCompletionHandler? = nil) -> ApiRequest {
+    func patchFile(from localFileUrl: URL, to destinationUrl: URL, with aditionalHeaders: [ApiHeader]? = nil, inBackground: Bool = true, useProgress: Bool = true, configuration: ApiService.Configuration = ApiService.Configuration.foreground, completion: ApiResponseCompletionHandler? = nil) -> ApiRequest {
         let configuration: Configuration = inBackground ? .background : .foreground
         return uploadFile(at: localFileUrl, to: destinationUrl, method: .patch, apiHeaders: aditionalHeaders, configuration: configuration, useProgress: useProgress, completion: completion)
     }
@@ -232,19 +232,19 @@ public extension ApiService {
      Downloads file using HTTP GET request.
 
      - Parameters:
-       - remoteFileUrl: URL of remote file to download.
-       - localUrl: URL on disc indicates where file should be saved.
-       - aditionalHeaders: Array of all aditional HTTP header fields.
-       - inBackground: Flag indicates if downloading should be performed in background or foreground.
-       - useProgress: Flag indicates if Progress object should be created.
-       - completion: Closure called when request is finished.
+     - remoteFileUrl: URL of remote file to download.
+     - localUrl: URL on disc indicates where file should be saved.
+     - aditionalHeaders: Array of all aditional HTTP header fields.
+     - inBackground: Flag indicates if downloading should be performed in background or foreground.
+     - useProgress: Flag indicates if Progress object should be created.
+     - completion: Closure called when request is finished.
 
      - Returns: ApiRequest object which allows to follow progress and manage request.
-     
+
      - Important: While using default file manager, if any file exists at *localUrl* it will be overridden by downloaded file.
      */
-    func downloadFile(from remoteFileUrl: URL, to localUrl: URL, with aditionalHeaders: [ApiHeader]? = nil, inBackground: Bool = true, useProgress: Bool = true, completion: ApiResponseCompletionHandler? = nil) -> ApiRequest {
-        let configuration: Configuration = inBackground ? .background : .foreground
+    func downloadFile(from remoteFileUrl: URL, to localUrl: URL, with aditionalHeaders: [ApiHeader]? = nil, inBackground: Bool = true, useProgress: Bool = true, configuration: ApiService.Configuration = ApiService.Configuration.background, completion: ApiResponseCompletionHandler? = nil) -> ApiRequest {
+        //        let configuration: Configuration = inBackground ? .background : .foreground
         return downloadFile(from: remoteFileUrl, to: localUrl, apiHeaders: aditionalHeaders, configuration: configuration, useProgress: useProgress, completion: completion)
     }
 }
@@ -256,16 +256,16 @@ public extension ApiService {
      Uploads file using HTTP request.
 
      - Parameters:
-       - localFileUrl: URL on disc of the resource to upload.
-       - destinationUrl: URL of the receiver.
-       - method: HTTP method which should be used.
-       - aditionalHeaders: Array of all aditional HTTP header fields.
-       - configuration: Custom or one of predefined *ApiService.Configuration* object.
-       - progress: Flag indicates if Progress object should be created.
-       - completion: Closure called when request is finished.
+     - localFileUrl: URL on disc of the resource to upload.
+     - destinationUrl: URL of the receiver.
+     - method: HTTP method which should be used.
+     - aditionalHeaders: Array of all aditional HTTP header fields.
+     - configuration: Custom or one of predefined *ApiService.Configuration* object.
+     - progress: Flag indicates if Progress object should be created.
+     - completion: Closure called when request is finished.
 
      - Returns: ApiRequest object which allows to follow progress and manage request.
-     
+
      This method allows to customize every request configuration. It may be very powerfull if you know what you are doing.
      */
     func uploadFile(from localFileUrl: URL, to destinationUrl: URL, with method: ApiMethod, aditionalHeaders: [ApiHeader]? = nil, configuration: Configuration = .background, progress: Bool = true, completion: ApiResponseCompletionHandler? = nil) -> ApiRequest {
@@ -276,17 +276,17 @@ public extension ApiService {
      Downloads file using HTTP GET request.
 
      - Parameters:
-       - remoteFileUrl: URL of remote file to download.
-       - localUrl: URL on disc indicates where file should be saved.
-       - aditionalHeaders: Array of all aditional HTTP header fields.
-       - configuration: Custom or one of predefined *ApiService.Configuration* object.
-       - progress: Flag indicates if Progress object should be created.
-       - completion: Closure called when request is finished.
+     - remoteFileUrl: URL of remote file to download.
+     - localUrl: URL on disc indicates where file should be saved.
+     - aditionalHeaders: Array of all aditional HTTP header fields.
+     - configuration: Custom or one of predefined *ApiService.Configuration* object.
+     - progress: Flag indicates if Progress object should be created.
+     - completion: Closure called when request is finished.
 
      - Returns: ApiRequest object which allows to follow progress and manage request.
 
      - Important: While using default file manager, if any file exists at *localUrl* it will be overridden by downloaded file.
-     
+
      This method allows to customize every request configuration. It may be very powerfull if you know what you are doing.
      */
     func downloadFile(from remoteFileUrl: URL, to localUrl: URL, with aditionalHeaders: [ApiHeader]? = nil, configuration: Configuration = .background, progress: Bool = true, completion: ApiResponseCompletionHandler? = nil) -> ApiRequest {

--- a/Sources/RESTLayer/Service/RestService.swift
+++ b/Sources/RESTLayer/Service/RestService.swift
@@ -26,11 +26,11 @@ public class RestService {
 
     /**
      - Parameters:
-       - baseUrl: Base URL string of API server.
-       - apiPath: Path of API on server.
-       - headerFields: Array of HTTP header fields which will be added to all requests. By default ContentType.json is set.
-       - coderProvider: Object providing *JSONCoder* and *JSONDecoder*.
-       - fileManager: Object of class implementing *FileManager* Protocol.
+     - baseUrl: Base URL string of API server.
+     - apiPath: Path of API on server.
+     - headerFields: Array of HTTP header fields which will be added to all requests. By default ContentType.json is set.
+     - coderProvider: Object providing *JSONCoder* and *JSONDecoder*.
+     - fileManager: Object of class implementing *FileManager* Protocol.
      */
     public init(baseUrl: String, apiPath: String? = nil, headerFields: [ApiHeader]? = [ApiHeader.ContentType.json], coderProvider: CoderProvider = DefaultCoderProvider(), fileManager: FileManager = DefaultFileManager()) {
         self.baseUrl = baseUrl
@@ -47,159 +47,159 @@ public extension RestService {
     /**
      Sends HTTP GET request.
      - Parameters:
-       - type: Type conforming *Decodable* protocol which should be returned in completion block.
-       - path: Path of the resource.
-       - aditionalHeaders: Additional header fields which should be sent with request.
-       - useProgress: Flag indicates if Progress object should be created.
-       - completion: Closure called when request is finished.
+     - type: Type conforming *Decodable* protocol which should be returned in completion block.
+     - path: Path of the resource.
+     - aditionalHeaders: Additional header fields which should be sent with request.
+     - useProgress: Flag indicates if Progress object should be created.
+     - completion: Closure called when request is finished.
      - Throws: RestService.Error if creating *URL* failed.
      - Returns: ApiRequest object which allows to follow progress and manage request.
      */
     @discardableResult
-    func get<Response: Decodable>(type: Response.Type, from path: ResourcePath, with aditionalHeaders: [ApiHeader]? = nil, useProgress: Bool = false, completion: RestResponseCompletionHandler<Response>? = nil) throws -> ApiRequest {
+    func get<Response: Decodable>(type: Response.Type, from path: ResourcePath, with aditionalHeaders: [ApiHeader]? = nil, useProgress: Bool = false, configuration: ApiService.Configuration = ApiService.Configuration.foreground, completion: RestResponseCompletionHandler<Response>? = nil) throws -> ApiRequest {
         let url = try requestUrl(for: path)
         let headers = apiHeaders(adding: aditionalHeaders)
         let completion = completionHandler(for: type, coder: coder, with: completion)
-        return apiService.getData(from: url, with: headers, useProgress: useProgress, completion: completion)
+        return apiService.getData(from: url, with: headers, configuration: configuration, useProgress: useProgress, completion: completion)
     }
 
     /**
      Sends HTTP POST request.
      - Parameters:
-       - value: Value of type conforming *Encodable* protocol which data should be sent with request.
-       - path: Path of the resource.
-       - aditionalHeaders: Additional header fields which should be sent with request.
-       - useProgress: Flag indicates if Progress object should be created.
-       - responseType: Type conforming *Decodable* protocol which should be returned in completion block.
-       - completion: Closure called when request is finished.
+     - value: Value of type conforming *Encodable* protocol which data should be sent with request.
+     - path: Path of the resource.
+     - aditionalHeaders: Additional header fields which should be sent with request.
+     - useProgress: Flag indicates if Progress object should be created.
+     - responseType: Type conforming *Decodable* protocol which should be returned in completion block.
+     - completion: Closure called when request is finished.
      - Throws: RestService.Error if creating *URL* failed or JSONEncoder error if encoding given value failed.
      - Returns: ApiRequest object which allows to follow progress and manage request.
      */
     @discardableResult
-    func post<Request: Encodable, Response: Decodable>(_ value: Request?, at path: ResourcePath, aditionalHeaders: [ApiHeader]? = nil, useProgress: Bool = false, responseType: Response.Type? = nil, completion: RestResponseCompletionHandler<Response>? = nil) throws -> ApiRequest {
+    func post<Request: Encodable, Response: Decodable>(_ value: Request?, at path: ResourcePath, aditionalHeaders: [ApiHeader]? = nil, useProgress: Bool = false, responseType: Response.Type? = nil, configuration: ApiService.Configuration = ApiService.Configuration.foreground, completion: RestResponseCompletionHandler<Response>? = nil) throws -> ApiRequest {
         let completion = completionHandler(for: Response.self, coder: coder, with: completion)
-        return try post(value, at: path, aditionalHeaders: aditionalHeaders, useProgress: useProgress, completion: completion)
+        return try post(value, at: path, aditionalHeaders: aditionalHeaders, useProgress: useProgress, configuration: configuration, completion: completion)
     }
 
     /**
      Sends HTTP POST request.
      - Parameters:
-       - value: Value of type conforming *Encodable* protocol which data should be sent with request.
-       - path: Path of the resource.
-       - aditionalHeaders: Additional header fields which should be sent with request.
-       - useProgress: Flag indicates if Progress object should be created.
-       - completion: Closure called when request is finished.
+     - value: Value of type conforming *Encodable* protocol which data should be sent with request.
+     - path: Path of the resource.
+     - aditionalHeaders: Additional header fields which should be sent with request.
+     - useProgress: Flag indicates if Progress object should be created.
+     - completion: Closure called when request is finished.
      - Throws: RestService.Error if creating *URL* failed or JSONEncoder error if encoding given value failed.
      - Returns: ApiRequest object which allows to follow progress and manage request.
      */
     @discardableResult
-    func post<Request: Encodable>(_ value: Request?, at path: ResourcePath, aditionalHeaders: [ApiHeader]? = nil, useProgress: Bool = false, completion: RestSimpleResponseCompletionHandler? = nil) throws -> ApiRequest {
+    func post<Request: Encodable>(_ value: Request?, at path: ResourcePath, aditionalHeaders: [ApiHeader]? = nil, useProgress: Bool = false, configuration: ApiService.Configuration = ApiService.Configuration.foreground, completion: RestSimpleResponseCompletionHandler? = nil) throws -> ApiRequest {
         let completion = completionHandler(with: completion)
-        return try post(value, at: path, aditionalHeaders: aditionalHeaders, useProgress: useProgress, completion: completion)
+        return try post(value, at: path, aditionalHeaders: aditionalHeaders, useProgress: useProgress, configuration: configuration, completion: completion)
     }
 
     /**
      Sends HTTP PUT request.
      - Parameters:
-       - value: Value of type conforming *Encodable* protocol which data should be sent with request.
-       - path: Path of the resource.
-       - aditionalHeaders: Additional header fields which should be sent with request.
-       - useProgress: Flag indicates if Progress object should be created.
-       - responseType: Type conforming *Decodable* protocol which should be returned in completion block.
-       - completion: Closure called when request is finished.
+     - value: Value of type conforming *Encodable* protocol which data should be sent with request.
+     - path: Path of the resource.
+     - aditionalHeaders: Additional header fields which should be sent with request.
+     - useProgress: Flag indicates if Progress object should be created.
+     - responseType: Type conforming *Decodable* protocol which should be returned in completion block.
+     - completion: Closure called when request is finished.
      - Throws: RestService.Error if creating *URL* failed or JSONEncoder error if encoding given value failed.
      - Returns: ApiRequest object which allows to follow progress and manage request.
      */
     @discardableResult
-    func put<Request: Encodable, Response: Decodable>(_ value: Request?, at path: ResourcePath, aditionalHeaders: [ApiHeader]? = nil, useProgress: Bool = false, responseType: Response.Type? = nil, completion: RestResponseCompletionHandler<Response>? = nil) throws -> ApiRequest {
+    func put<Request: Encodable, Response: Decodable>(_ value: Request?, at path: ResourcePath, aditionalHeaders: [ApiHeader]? = nil, useProgress: Bool = false, responseType: Response.Type? = nil, configuration: ApiService.Configuration = ApiService.Configuration.foreground, completion: RestResponseCompletionHandler<Response>? = nil) throws -> ApiRequest {
         let completion = completionHandler(for: Response.self, coder: coder, with: completion)
-        return try put(value, at: path, aditionalHeaders: aditionalHeaders, useProgress: useProgress, completion: completion)
+        return try put(value, at: path, aditionalHeaders: aditionalHeaders, useProgress: useProgress, configuration: configuration, completion: completion)
     }
 
     /**
      Sends HTTP PUT request.
      - Parameters:
-       - value: Value of type conforming *Encodable* protocol which data should be sent with request.
-       - path: Path of the resource.
-       - aditionalHeaders: Additional header fields which should be sent with request.
-       - useProgress: Flag indicates if Progress object should be created.
-       - completion: Closure called when request is finished.
+     - value: Value of type conforming *Encodable* protocol which data should be sent with request.
+     - path: Path of the resource.
+     - aditionalHeaders: Additional header fields which should be sent with request.
+     - useProgress: Flag indicates if Progress object should be created.
+     - completion: Closure called when request is finished.
      - Throws: RestService.Error if creating *URL* failed or JSONEncoder error if encoding given value failed.
      - Returns: ApiRequest object which allows to follow progress and manage request.
      */
     @discardableResult
-    func put<Request: Encodable>(_ value: Request?, at path: ResourcePath, aditionalHeaders: [ApiHeader]? = nil, useProgress: Bool = false, completion: RestSimpleResponseCompletionHandler? = nil) throws -> ApiRequest {
+    func put<Request: Encodable>(_ value: Request?, at path: ResourcePath, aditionalHeaders: [ApiHeader]? = nil, useProgress: Bool = false, configuration: ApiService.Configuration = ApiService.Configuration.foreground, completion: RestSimpleResponseCompletionHandler? = nil) throws -> ApiRequest {
         let completion = completionHandler(with: completion)
-        return try put(value, at: path, aditionalHeaders: aditionalHeaders, useProgress: useProgress, completion: completion)
+        return try put(value, at: path, aditionalHeaders: aditionalHeaders, useProgress: useProgress, configuration: configuration, completion: completion)
     }
 
     /**
      Sends HTTP PATCH request.
      - Parameters:
-       - value: Value of type conforming *Encodable* protocol which data should be sent with request.
-       - aditionalHeaders: Additional header fields which should be sent with request.
-       - useProgress: Flag indicates if Progress object should be created.
-       - responseType: Type conforming *Decodable* protocol which should be returned in completion block.
-       - completion: Closure called when request is finished.
+     - value: Value of type conforming *Encodable* protocol which data should be sent with request.
+     - aditionalHeaders: Additional header fields which should be sent with request.
+     - useProgress: Flag indicates if Progress object should be created.
+     - responseType: Type conforming *Decodable* protocol which should be returned in completion block.
+     - completion: Closure called when request is finished.
      - Throws: RestService.Error if creating *URL* failed or JSONEncoder error if encoding given value failed.
      - Returns: ApiRequest object which allows to follow progress and manage request.
      */
     @discardableResult
-    func patch<Request: Encodable, Response: Decodable>(_ value: Request?, at path: ResourcePath, aditionalHeaders: [ApiHeader]? = nil, useProgress: Bool = false, responseType: Response.Type? = nil, completion: RestResponseCompletionHandler<Response>? = nil) throws -> ApiRequest {
+    func patch<Request: Encodable, Response: Decodable>(_ value: Request?, at path: ResourcePath, aditionalHeaders: [ApiHeader]? = nil, useProgress: Bool = false, responseType: Response.Type? = nil, configuration: ApiService.Configuration = ApiService.Configuration.foreground, completion: RestResponseCompletionHandler<Response>? = nil) throws -> ApiRequest {
         let completion = completionHandler(for: Response.self, coder: coder, with: completion)
-        return try patch(value, at: path, aditionalHeaders: aditionalHeaders, useProgress: useProgress, completion: completion)
+        return try patch(value, at: path, aditionalHeaders: aditionalHeaders, useProgress: useProgress, configuration: configuration, completion: completion)
     }
 
     /**
      Sends HTTP PATCH request.
      - Parameters:
-       - value: Value of type conforming *Encodable* protocol which data should be sent with request.
-       - path: Path of the resource.
-       - aditionalHeaders: Additional header fields which should be sent with request.
-       - useProgress: Flag indicates if Progress object should be created.
-       - completion: Closure called when request is finished.
+     - value: Value of type conforming *Encodable* protocol which data should be sent with request.
+     - path: Path of the resource.
+     - aditionalHeaders: Additional header fields which should be sent with request.
+     - useProgress: Flag indicates if Progress object should be created.
+     - completion: Closure called when request is finished.
      - Throws: RestService.Error if creating *URL* failed or JSONEncoder error if encoding given value failed.
      - Returns: ApiRequest object which allows to follow progress and manage request.
      */
     @discardableResult
-    func patch<Request: Encodable>(_ value: Request?, at path: ResourcePath, aditionalHeaders: [ApiHeader]? = nil, useProgress: Bool = false, completion: RestSimpleResponseCompletionHandler? = nil) throws -> ApiRequest {
+    func patch<Request: Encodable>(_ value: Request?, at path: ResourcePath, aditionalHeaders: [ApiHeader]? = nil, useProgress: Bool = false, configuration: ApiService.Configuration = ApiService.Configuration.foreground, completion: RestSimpleResponseCompletionHandler? = nil) throws -> ApiRequest {
         let completion = completionHandler(with: completion)
-        return try patch(value, at: path, aditionalHeaders: aditionalHeaders, useProgress: useProgress, completion: completion)
+        return try patch(value, at: path, aditionalHeaders: aditionalHeaders, useProgress: useProgress, configuration: configuration, completion: completion)
     }
 
     /**
      Sends HTTP DELETE request.
      - Parameters:
-       - value: Value of type conforming *Encodable* protocol which data should be sent with request.
-       - path: Path of the resource.
-       - aditionalHeaders: Additional header fields which should be sent with request.
-       - useProgress: Flag indicates if Progress object should be created.
-       - responseType: Type conforming *Decodable* protocol which should be returned in completion block.
-       - completion: Closure called when request is finished.
+     - value: Value of type conforming *Encodable* protocol which data should be sent with request.
+     - path: Path of the resource.
+     - aditionalHeaders: Additional header fields which should be sent with request.
+     - useProgress: Flag indicates if Progress object should be created.
+     - responseType: Type conforming *Decodable* protocol which should be returned in completion block.
+     - completion: Closure called when request is finished.
      - Throws: RestService.Error if creating *URL* failed or JSONEncoder error if encoding given value failed.
      - Returns: ApiRequest object which allows to follow progress and manage request.
      */
     @discardableResult
-    func delete<Request: Encodable, Response: Decodable>(_ value: Request? = nil, at path: ResourcePath, aditionalHeaders: [ApiHeader]? = nil, useProgress: Bool = false, responseType: Response.Type? = nil, completion: RestResponseCompletionHandler<Response>? = nil) throws -> ApiRequest {
+    func delete<Request: Encodable, Response: Decodable>(_ value: Request? = nil, at path: ResourcePath, aditionalHeaders: [ApiHeader]? = nil, useProgress: Bool = false, responseType: Response.Type? = nil, configuration: ApiService.Configuration = ApiService.Configuration.foreground, completion: RestResponseCompletionHandler<Response>? = nil) throws -> ApiRequest {
         let completion = completionHandler(for: Response.self, coder: coder, with: completion)
-        return try delete(value, at: path, aditionalHeaders: aditionalHeaders, useProgress: useProgress, completion: completion)
+        return try delete(value, at: path, aditionalHeaders: aditionalHeaders, useProgress: useProgress, configuration: configuration, completion: completion)
     }
 
     /**
      Sends HTTP DELETE request.
      - Parameters:
-       - value: Value of type conforming *Encodable* protocol which data should be sent with request.
-       - path: Path of the resource.
-       - aditionalHeaders: Additional header fields which should be sent with request.
-       - useProgress: Flag indicates if Progress object should be created.
-       - completion: Closure called when request is finished.
+     - value: Value of type conforming *Encodable* protocol which data should be sent with request.
+     - path: Path of the resource.
+     - aditionalHeaders: Additional header fields which should be sent with request.
+     - useProgress: Flag indicates if Progress object should be created.
+     - completion: Closure called when request is finished.
      - Throws: RestService.Error if creating *URL* failed or JSONEncoder error if encoding given value failed.
      - Returns: ApiRequest object which allows to follow progress and manage request.
      */
     @discardableResult
-    func delete<Request: Encodable>(_ value: Request? = nil, at path: ResourcePath, aditionalHeaders: [ApiHeader]? = nil, useProgress: Bool = false, completion: RestSimpleResponseCompletionHandler? = nil) throws -> ApiRequest {
+    func delete<Request: Encodable>(_ value: Request? = nil, at path: ResourcePath, aditionalHeaders: [ApiHeader]? = nil, useProgress: Bool = false, configuration: ApiService.Configuration = ApiService.Configuration.foreground, completion: RestSimpleResponseCompletionHandler? = nil) throws -> ApiRequest {
         let completion = completionHandler(with: completion)
-        return try delete(value, at: path, aditionalHeaders: aditionalHeaders, useProgress: useProgress, completion: completion)
+        return try delete(value, at: path, aditionalHeaders: aditionalHeaders, useProgress: useProgress, configuration: configuration, completion: completion)
     }
 }
 
@@ -209,77 +209,77 @@ public extension RestService {
     /**
      Sends HTTP GET request for file.
      - Parameters:
-       - path: Path of file to download.
-       - destinationUrl: Local url, where file should be saved.
-       - inBackground: Flag indicates if downloading should be performed in background or foreground.
-       - aditionalHeaders: Additional header fields which should be sent with request.
-       - useProgress: Flag indicates if Progress object should be created.
-       - completion: Closure called when request is finished.
+     - path: Path of file to download.
+     - destinationUrl: Local url, where file should be saved.
+     - inBackground: Flag indicates if downloading should be performed in background or foreground.
+     - aditionalHeaders: Additional header fields which should be sent with request.
+     - useProgress: Flag indicates if Progress object should be created.
+     - completion: Closure called when request is finished.
      - Throws: RestService.Error if creating *URL* failed.
      - Returns: ApiRequest object which allows to follow progress and manage request.
      */
-    func getFile(at path: ResourcePath, saveAt destinationUrl: URL, inBackground: Bool = true, aditionalHeaders: [ApiHeader]? = nil, useProgress: Bool = true, completion: RestSimpleResponseCompletionHandler? = nil) throws -> ApiRequest {
+    func getFile(at path: ResourcePath, saveAt destinationUrl: URL, inBackground: Bool = true, aditionalHeaders: [ApiHeader]? = nil, useProgress: Bool = true, configuration: ApiService.Configuration = ApiService.Configuration.foreground, completion: RestSimpleResponseCompletionHandler? = nil) throws -> ApiRequest {
         let url = try requestUrl(for: path)
         let headers = apiHeaders(adding: aditionalHeaders)
         let completion = completionHandler(with: completion)
-        return apiService.downloadFile(from: url, to: destinationUrl, with: headers, inBackground: inBackground, useProgress: useProgress, completion: completion)
+        return apiService.downloadFile(from: url, to: destinationUrl, with: headers, inBackground: inBackground, useProgress: useProgress, configuration: configuration, completion: completion)
     }
 
     /**
      Sends HTTP POST request with file.
      - Parameters:
-       - url: Local url, where file should be saved.
-       - path: Destination path of file.
-       - inBackground: Flag indicates if downloading should be performed in background or foreground.
-       - aditionalHeaders: Additional header fields which should be sent with request.
-       - useProgress: Flag indicates if Progress object should be created.
-       - completion: Closure called when request is finished.
+     - url: Local url, where file should be saved.
+     - path: Destination path of file.
+     - inBackground: Flag indicates if downloading should be performed in background or foreground.
+     - aditionalHeaders: Additional header fields which should be sent with request.
+     - useProgress: Flag indicates if Progress object should be created.
+     - completion: Closure called when request is finished.
      - Throws: RestService.Error if creating *URL* failed.
      - Returns: ApiRequest object which allows to follow progress and manage request.
      */
-    func postFile(from url: URL, at path: ResourcePath, inBackground: Bool = true, aditionalHeaders: [ApiHeader]? = nil, useProgress: Bool = true, completion: RestSimpleResponseCompletionHandler? = nil) throws -> ApiRequest {
+    func postFile(from url: URL, at path: ResourcePath, inBackground: Bool = true, aditionalHeaders: [ApiHeader]? = nil, useProgress: Bool = true, configuration: ApiService.Configuration = ApiService.Configuration.foreground, completion: RestSimpleResponseCompletionHandler? = nil) throws -> ApiRequest {
         let destinationUrl = try requestUrl(for: path)
         let headers = apiHeaders(adding: aditionalHeaders)
         let completion = completionHandler(with: completion)
-        return apiService.postFile(from: url, to: destinationUrl, with: headers, inBackground: inBackground, useProgress: useProgress, completion: completion)
+        return apiService.postFile(from: url, to: destinationUrl, with: headers, inBackground: inBackground, useProgress: useProgress, configuration: configuration, completion: completion)
     }
 
     /**
      Sends HTTP PUT request with file.
      - Parameters:
-       - url: Local url, where file should be saved.
-       - path: Destination path of file.
-       - inBackground: Flag indicates if downloading should be performed in background or foreground.
-       - aditionalHeaders: Additional header fields which should be sent with request.
-       - useProgress: Flag indicates if Progress object should be created.
-       - completion: Closure called when request is finished.
+     - url: Local url, where file should be saved.
+     - path: Destination path of file.
+     - inBackground: Flag indicates if downloading should be performed in background or foreground.
+     - aditionalHeaders: Additional header fields which should be sent with request.
+     - useProgress: Flag indicates if Progress object should be created.
+     - completion: Closure called when request is finished.
      - Throws: RestService.Error if creating *URL* failed.
      - Returns: ApiRequest object which allows to follow progress and manage request.
      */
-    func putFile(from url: URL, at path: ResourcePath, inBackground: Bool = true, aditionalHeaders: [ApiHeader]? = nil, useProgress: Bool = true, completion: RestSimpleResponseCompletionHandler? = nil) throws -> ApiRequest {
+    func putFile(from url: URL, at path: ResourcePath, inBackground: Bool = true, aditionalHeaders: [ApiHeader]? = nil, useProgress: Bool = true, configuration: ApiService.Configuration = ApiService.Configuration.foreground, completion: RestSimpleResponseCompletionHandler? = nil) throws -> ApiRequest {
         let destinationUrl = try requestUrl(for: path)
         let headers = apiHeaders(adding: aditionalHeaders)
         let completion = completionHandler(with: completion)
-        return apiService.putFile(from: url, to: destinationUrl, with: headers, inBackground: inBackground, useProgress: useProgress, completion: completion)
+        return apiService.putFile(from: url, to: destinationUrl, with: headers, inBackground: inBackground, useProgress: useProgress, configuration: configuration, completion: completion)
     }
 
     /**
      Sends HTTP PATCH request with file.
      - Parameters:
-       - url: Local url, where file should be saved.
-       - path: Destination path of file.
-       - inBackground: Flag indicates if downloading should be performed in background or foreground.
-       - aditionalHeaders: Additional header fields which should be sent with request.
-       - useProgress: Flag indicates if Progress object should be created.
-       - completion: Closure called when request is finished.
+     - url: Local url, where file should be saved.
+     - path: Destination path of file.
+     - inBackground: Flag indicates if downloading should be performed in background or foreground.
+     - aditionalHeaders: Additional header fields which should be sent with request.
+     - useProgress: Flag indicates if Progress object should be created.
+     - completion: Closure called when request is finished.
      - Throws: RestService.Error if creating *URL* failed.
      - Returns: ApiRequest object which allows to follow progress and manage request.
      */
-    func patchFile(from url: URL, at path: ResourcePath, inBackground: Bool = true, aditionalHeaders: [ApiHeader]? = nil, useProgress: Bool = true, completion: RestSimpleResponseCompletionHandler? = nil) throws -> ApiRequest {
+    func patchFile(from url: URL, at path: ResourcePath, inBackground: Bool = true, aditionalHeaders: [ApiHeader]? = nil, useProgress: Bool = true, configuration: ApiService.Configuration = ApiService.Configuration.foreground, completion: RestSimpleResponseCompletionHandler? = nil) throws -> ApiRequest {
         let destinationUrl = try requestUrl(for: path)
         let headers = apiHeaders(adding: aditionalHeaders)
         let completion = completionHandler(with: completion)
-        return apiService.patchFile(from: url, to: destinationUrl, with: headers, inBackground: inBackground, useProgress: useProgress, completion: completion)
+        return apiService.patchFile(from: url, to: destinationUrl, with: headers, inBackground: inBackground, useProgress: useProgress, configuration: configuration, completion: completion)
     }
 }
 
@@ -378,34 +378,34 @@ private extension RestService {
 private extension RestService {
 
     ///Posts given `value` using `apiService`.
-    func post<Request: Encodable>(_ value: Request?, at path: ResourcePath, aditionalHeaders: [ApiHeader]?, useProgress: Bool, completion: ApiResponseCompletionHandler?) throws -> ApiRequest {
+    func post<Request: Encodable>(_ value: Request?, at path: ResourcePath, aditionalHeaders: [ApiHeader]?, useProgress: Bool, configuration: ApiService.Configuration = ApiService.Configuration.foreground, completion: ApiResponseCompletionHandler?) throws -> ApiRequest {
         let url = try requestUrl(for: path)
         let data = try requestData(for: value)
         let headers = apiHeaders(adding: aditionalHeaders)
-        return apiService.post(data: data, at: url, with: headers, useProgress: useProgress, completion: completion)
+        return apiService.post(data: data, at: url, with: headers, configuration: configuration, useProgress: useProgress, completion: completion)
     }
 
     ///Puts given `value` using `apiService`.
-    func put<Request: Encodable>(_ value: Request?, at path: ResourcePath, aditionalHeaders: [ApiHeader]?, useProgress: Bool, completion: ApiResponseCompletionHandler?) throws -> ApiRequest {
+    func put<Request: Encodable>(_ value: Request?, at path: ResourcePath, aditionalHeaders: [ApiHeader]?, useProgress: Bool, configuration: ApiService.Configuration = ApiService.Configuration.foreground, completion: ApiResponseCompletionHandler?) throws -> ApiRequest {
         let url = try requestUrl(for: path)
         let data = try requestData(for: value)
         let headers = apiHeaders(adding: aditionalHeaders)
-        return apiService.put(data: data, at: url, with: headers, useProgress: useProgress, completion: completion)
+        return apiService.put(data: data, at: url, with: headers, configuration: configuration, useProgress: useProgress, completion: completion)
     }
 
     ///Patches given `value` using `apiService`.
-    func patch<Request: Encodable>(_ value: Request?, at path: ResourcePath, aditionalHeaders: [ApiHeader]?, useProgress: Bool, completion: ApiResponseCompletionHandler?) throws -> ApiRequest {
+    func patch<Request: Encodable>(_ value: Request?, at path: ResourcePath, aditionalHeaders: [ApiHeader]?, useProgress: Bool, configuration: ApiService.Configuration = ApiService.Configuration.foreground, completion: ApiResponseCompletionHandler?) throws -> ApiRequest {
         let url = try requestUrl(for: path)
         let data = try requestData(for: value)
         let headers = apiHeaders(adding: aditionalHeaders)
-        return apiService.patch(data: data, at: url, with: headers, useProgress: useProgress, completion: completion)
+        return apiService.patch(data: data, at: url, with: headers, configuration: configuration, useProgress: useProgress, completion: completion)
     }
 
     ///Deletes given `value` using `apiService`.
-    func delete<Request: Encodable>(_ value: Request?, at path: ResourcePath, aditionalHeaders: [ApiHeader]?, useProgress: Bool, completion: ApiResponseCompletionHandler?) throws -> ApiRequest {
+    func delete<Request: Encodable>(_ value: Request?, at path: ResourcePath, aditionalHeaders: [ApiHeader]?, useProgress: Bool, configuration: ApiService.Configuration = ApiService.Configuration.foreground, completion: ApiResponseCompletionHandler?) throws -> ApiRequest {
         let url = try requestUrl(for: path)
         let data = try requestData(for: value)
         let headers = apiHeaders(adding: aditionalHeaders)
-        return apiService.delete(data: data, at: url, with: headers, useProgress: useProgress, completion: completion)
+        return apiService.delete(data: data, at: url, with: headers, configuration: configuration, useProgress: useProgress, completion: completion)
     }
 }


### PR DESCRIPTION
The requests are by default using the **Configuration**, current changes are introducing custom configuration to every request started from **API Service** Layer.

For example we can now set timeouts to requests from API Service.